### PR TITLE
Removed requestBody in Logout / #143, #144 ValidateTeamPaused moved to teamService

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/CalendarController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/CalendarController.java
@@ -2,7 +2,7 @@ package ch.uzh.ifi.hase.soprafs24.controller;
 
 import ch.uzh.ifi.hase.soprafs24.service.CalendarService;
 import ch.uzh.ifi.hase.soprafs24.service.UserService;
-import ch.uzh.ifi.hase.soprafs24.service.TaskService;
+import ch.uzh.ifi.hase.soprafs24.service.TeamService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -21,13 +21,13 @@ public class CalendarController {
 
     private final CalendarService calendarService;
     private final UserService userService;
-    private final TaskService taskService;
+    private final TeamService teamService;
 
     @Autowired
-    public CalendarController(CalendarService calendarService, UserService userService, TaskService taskService) {
+    public CalendarController(CalendarService calendarService, UserService userService, TeamService teamService) {
         this.calendarService = calendarService;
         this.userService = userService;
-        this.taskService = taskService;
+        this.teamService = teamService;
     }
     
 
@@ -39,7 +39,7 @@ public class CalendarController {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized: Invalid token.");
         }
         // Validate if the team is paused
-        taskService.validateTeamPaused(token);
+        teamService.validateTeamPaused(token);
         // Get authenticated user ID
         Long userId = userService.findIDforToken(token);
         if (userId == null) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/TaskController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/TaskController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs24.service.TeamService;
 
 
 import java.util.ArrayList;
@@ -19,18 +20,20 @@ public class TaskController {
 
   private final TaskService taskService;
   private final UserRepository userrepository;
+  private final TeamService teamService;
   
 
-  TaskController(TaskService taskService, UserRepository userrepository) {
+  TaskController(TaskService taskService, UserRepository userrepository, TeamService teamService) {
     this.taskService = taskService;
     this.userrepository = userrepository;
+    this.teamService = teamService;
   }
     @PostMapping("/tasks")
     @ResponseStatus(HttpStatus.CREATED)
     public TaskGetDTO createTask(@RequestBody TaskPostDTO taskPostDTO, @RequestHeader("Authorization") String authorizationHeader) {
         // Extract the token from the Bearer header
         String userToken = validateAuthorizationHeader(authorizationHeader);
-        taskService.validateTeamPaused(userToken);
+        teamService.validateTeamPaused(userToken);
         // validate the DTO before converting to catch errors
         taskService.validatePostDto(taskPostDTO);
         // Convert the incoming DTO to an entity
@@ -48,7 +51,7 @@ public class TaskController {
                                         @RequestHeader("Authorization") String authorizationHeader) {
         // Validate the user token
         String userToken = validateAuthorizationHeader(authorizationHeader);
-        taskService.validateTeamPaused(userToken);
+        teamService.validateTeamPaused(userToken);
         // Retrieve all tasks using the service
         List<Task> tasks = taskService.getFilteredTasks(isActive, type);
         // Convert the list of entities to a list of DTOs for the response
@@ -67,7 +70,7 @@ public class TaskController {
     public TaskGetDTO getTask(@PathVariable Long taskId, @RequestHeader("Authorization") String authorizationHeader) {
         // Validate the user token
         String userToken = validateAuthorizationHeader(authorizationHeader);
-        taskService.validateTeamPaused(userToken);
+        teamService.validateTeamPaused(userToken);
         // Retrieve the task using the service
         Task task = taskService.getTaskById(taskId);
         if (task == null) {
@@ -83,7 +86,7 @@ public class TaskController {
         try {
             // Validate the user token
             String userToken = validateAuthorizationHeader(authorizationHeader);
-            taskService.validateTeamPaused(userToken);
+            teamService.validateTeamPaused(userToken);
             // Validate whether the user can edit the task
             taskService.validateCreator(userToken, taskId);
             Task task = taskService.getTaskById(taskId);
@@ -101,7 +104,7 @@ public class TaskController {
     public TaskGetDTO updateTask(@PathVariable Long taskId, @RequestBody TaskPutDTO taskPutDTO, @RequestHeader("Authorization") String authorizationHeader) {
         // Validate the user token
         String userToken = validateAuthorizationHeader(authorizationHeader);
-        taskService.validateTeamPaused(userToken);
+        teamService.validateTeamPaused(userToken);
         // check if task is in the same team as the user
         taskService.validateTaskInTeam(userToken, taskId);
         // Checks if user is the creator of the task and if task exists
@@ -121,7 +124,7 @@ public class TaskController {
     public TaskGetDTO claimTasks(@PathVariable Long taskId, @RequestHeader("Authorization") String authorizationHeader) {
         // Validate the user token        
         String userToken = validateAuthorizationHeader(authorizationHeader);
-        taskService.validateTeamPaused(userToken);
+        teamService.validateTeamPaused(userToken);
         //Retrieves Task by Id or throws Http error if the task doesn't exist
         Task existingTask = taskService.getTaskById(taskId);
         //Claims the task for the user and assigns the user to the correct field 
@@ -137,7 +140,7 @@ public class TaskController {
         
         // Validate the user token
         String userToken = validateAuthorizationHeader(authorizationHeader);
-        taskService.validateUserToken(userToken);
+        teamService.validateTeamPaused(userToken);
         // check if task is in the same team as the user
         taskService.validateTaskInTeam(userToken, taskId);
         // Checks if user is the creator of the task and if task exists
@@ -168,7 +171,7 @@ public class TaskController {
     public void deleteTask(@PathVariable Long taskId, @RequestHeader("Authorization") String authorizationHeader) {
         // Validate the user token
         String userToken = validateAuthorizationHeader(authorizationHeader);
-        taskService.validateTeamPaused(userToken);
+        teamService.validateTeamPaused(userToken);
         // check if task is in the same team as the user
         taskService.validateTaskInTeam(userToken, taskId);
         // Checks if user is the creator of the task and if task exists

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
@@ -101,18 +101,16 @@ public class UserController {
 
   @PutMapping("/logout")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  public void logoff(@RequestBody UserPutDTO userPutDTO, @RequestHeader("Authorization") String authorizationHeader) {
+  public void logoff(@RequestHeader("Authorization") String authorizationHeader) {
     String token = validateAuthorizationHeader(authorizationHeader);
     if (!userService.validateToken(token)) {
         throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unauthorized: Invalid token.");
     }
     Long authenticatedUserId = userService.findIDforToken(token);
-    // Ensure the user ID in the request matches the authenticated user ID
-    if (!authenticatedUserId.equals(userPutDTO.getId())) {
-        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Forbidden: You can only log off your own account.");
-    }
-    User userInput = DTOMapper.INSTANCE.convertUserPutDTOtoEntity(userPutDTO);
-    userService.logoffUser(userInput);
+    
+    User user = userService.getUserById(authenticatedUserId);
+
+    userService.logoffUser(user);
   }
 
   @PutMapping("/users/{userId}")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/CalendarService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/CalendarService.java
@@ -39,6 +39,11 @@ public class CalendarService {
     private static final String OFFLINE = "offline";  // Constant for "offline"
     private static final String DATETIME_FIELD = "dateTime";
     private static final String STATUS_FIELD = "status"; // Constant for "status"
+    private static final String START = "start"; // Constant for "start"
+    private static final String END = "end"; // Constant for "end"
+    private static final String SOURCE = "source"; // Constant for "source"
+    private static final String SUMMARY = "summary"; // Constant for "summary"
+    private static final String DESCRIPTION = "description"; // Constant for "description"
 
     @Value("${REDIRECT_URI:redirect.uri}")
     private String redirectUri;
@@ -112,12 +117,12 @@ public class CalendarService {
         try {
             Calendar userCalendar = getCalendarServiceForUser(userId);
 
-            if ("task".equals(taskEvent.get("source"))) {
+            if ("task".equals(taskEvent.get(SOURCE))) {
                 Event event = new Event()
-                        .setSummary((String) taskEvent.get("summary"))
-                        .setDescription((String) taskEvent.get("description"))
-                        .setStart(new EventDateTime().setDateTime(new DateTime((String) ((Map<?, ?>) taskEvent.get("start")).get(DATETIME_FIELD))))
-                        .setEnd(new EventDateTime().setDateTime(new DateTime((String) ((Map<?, ?>) taskEvent.get("end")).get(DATETIME_FIELD))));
+                        .setSummary((String) taskEvent.get(SUMMARY))
+                        .setDescription((String) taskEvent.get(DESCRIPTION))
+                        .setStart(new EventDateTime().setDateTime(new DateTime((String) ((Map<?, ?>) taskEvent.get(START)).get(DATETIME_FIELD))))
+                        .setEnd(new EventDateTime().setDateTime(new DateTime((String) ((Map<?, ?>) taskEvent.get(END)).get(DATETIME_FIELD))));
 
                 if ("active".equals(taskEvent.get(STATUS_FIELD))) {
                     Event inserted = userCalendar.events().insert(PRIMARY, event).execute();
@@ -268,11 +273,11 @@ public class CalendarService {
         for (Event ge : googleEvents) {
             Map<String, Object> map = new HashMap<>();
             map.put("id", ge.getId());
-            map.put("summary", ge.getSummary());
-            map.put("description", ge.getDescription());
-            map.put("start", ge.getStart());
-            map.put("end", ge.getEnd());
-            map.put("source", "google");
+            map.put(SUMMARY, ge.getSummary());
+            map.put(DESCRIPTION, ge.getDescription());
+            map.put(START, ge.getStart());
+            map.put(END, ge.getEnd());
+            map.put(SOURCE, "google");
             combinedEvents.add(map);
         }
     
@@ -281,16 +286,16 @@ public class CalendarService {
         for (Task task : tasks) {
             Map<String, Object> taskEvent = new HashMap<>();
             taskEvent.put("id", "task-" + task.getId());
-            taskEvent.put("summary", "[TASK] " + task.getName());
-            taskEvent.put("description", task.getDescription());
+            taskEvent.put(SUMMARY, "[TASK] " + task.getName());
+            taskEvent.put(DESCRIPTION, task.getDescription());
     
             // Convert task deadline to Google Calendar-compatible format
-            taskEvent.put("start", Map.of(DATETIME_FIELD, toISOString(task.getDeadline())));
-            taskEvent.put("end", Map.of(DATETIME_FIELD, toISOString(task.getDeadline())));
+            taskEvent.put(START, Map.of(DATETIME_FIELD, toISOString(task.getDeadline())));
+            taskEvent.put(END, Map.of(DATETIME_FIELD, toISOString(task.getDeadline())));
     
             // Optional: Add task color
             taskEvent.put("colorId", task.getColor() != null ? task.getColor().toString() : null);
-            taskEvent.put("source", "task");
+            taskEvent.put(SOURCE, "task");
             taskEvent.put(STATUS_FIELD, "active");
     
             combinedEvents.add(taskEvent);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/TaskService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/TaskService.java
@@ -1,10 +1,8 @@
 package ch.uzh.ifi.hase.soprafs24.service;
 
 import ch.uzh.ifi.hase.soprafs24.entity.Task;
-import ch.uzh.ifi.hase.soprafs24.entity.Team;
 import ch.uzh.ifi.hase.soprafs24.repository.TaskRepository;
 import ch.uzh.ifi.hase.soprafs24.repository.UserRepository;
-import ch.uzh.ifi.hase.soprafs24.repository.TeamRepository;
 import ch.uzh.ifi.hase.soprafs24.rest.dto.task.TaskPostDTO;
 import ch.uzh.ifi.hase.soprafs24.entity.User;
 
@@ -32,7 +30,6 @@ public class TaskService {
     private final Logger log = LoggerFactory.getLogger(TaskService.class);
     private final TaskRepository taskRepository;
     private final UserRepository userRepository;
-    private final TeamRepository teamRepository;
     private final CalendarService calendarService;
     private String recurringTask = "recurring"; 
     private String additionalTask = "additional"; 
@@ -41,11 +38,9 @@ public class TaskService {
     public TaskService(@Qualifier("taskRepository") TaskRepository taskRepository,
             @Qualifier("userRepository") UserRepository userRepository, 
             @Qualifier("userService") UserService userService,
-            @Qualifier("calendarService") CalendarService calendarService,
-            @Qualifier("teamRepository") TeamRepository teamRepository) {
+            @Qualifier("calendarService") CalendarService calendarService) {
         this.taskRepository = taskRepository;
         this.userRepository = userRepository;
-        this.teamRepository = teamRepository;
         this.userService = userService;
         this.calendarService = calendarService;
     }
@@ -213,24 +208,6 @@ public class TaskService {
                             .collect(Collectors.toList());
         }
         return allTasks;
-    }
-
-    public void validateTeamPaused(String userToken) {
-        validateUserToken(userToken);
-    
-        User user = userRepository.findByToken(userToken);
-        if (user == null) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid user token");
-        }
-    
-        Long teamId = user.getTeamId();
-        Team team = teamRepository.findTeamById(teamId);
-        if (team == null) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Team not found");
-        }
-        if (Boolean.TRUE.equals(team.getIsPaused())) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Team is paused");
-        }
     }
 
     public void pauseAllTasksInTeam() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/TeamService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/TeamService.java
@@ -195,6 +195,24 @@ public class TeamService {
     teamRepository.save(team);
     teamRepository.flush();
   }
+
+  public void validateTeamPaused(String userToken) {
+    taskService.validateUserToken(userToken);
+
+    User user = userRepository.findByToken(userToken);
+    if (user == null) {
+        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid user token");
+    }
+
+    Long teamId = user.getTeamId();
+    Team team = teamRepository.findTeamById(teamId);
+    if (team == null) {
+        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Team not found");
+    }
+    if (Boolean.TRUE.equals(team.getIsPaused())) {
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Team is paused");
+    }
+}
   
   /**
    * This is a helper method that will check the uniqueness criteria of the

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/CalendarControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/CalendarControllerTest.java
@@ -2,6 +2,7 @@ package ch.uzh.ifi.hase.soprafs24.controller;
 
 import ch.uzh.ifi.hase.soprafs24.service.CalendarService;
 import ch.uzh.ifi.hase.soprafs24.service.TaskService;
+import ch.uzh.ifi.hase.soprafs24.service.TeamService;
 import ch.uzh.ifi.hase.soprafs24.service.UserService;
 
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,9 @@ class CalendarControllerTest {
 
     @MockBean
     private TaskService taskService;
+
+    @MockBean
+    private TeamService teamService;
 
     @MockBean
     private CalendarService calendarService;

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/UserControllerTest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
+
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.hasSize;
@@ -390,26 +391,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     }
     
     @Test
-    void PUT_logoff_failed_wrongUserId() throws Exception {
-        // given
-        Long authenticatedUserId = 1L;
-        Long differentUserId = 2L;
-        String validToken = "valid-token";
-        
-        UserPutDTO userPutDTO = new UserPutDTO();
-        userPutDTO.setId(differentUserId);  // Trying to log off a different user
-        
-        when(userService.validateToken(validToken)).thenReturn(true);
-        when(userService.findIDforToken(validToken)).thenReturn(authenticatedUserId);
-        
-        // when/then
-        MockHttpServletRequestBuilder putRequest = put("/logout")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(asJsonString(userPutDTO))
-            .header("Authorization", "Bearer " + validToken);
-        
-        mockMvc.perform(putRequest)
-            .andExpect(status().isForbidden());
+    void PUT_logoff_failed_invalidToken() throws Exception {
+    // given
+    String invalidToken = "invalid-token";
+    
+    when(userService.validateToken(invalidToken)).thenReturn(false);
+    
+    // when/then
+    mockMvc.perform(put("/logout")
+            .header("Authorization", "Bearer " + invalidToken))
+        .andExpect(status().isUnauthorized());
     }
     
     @Test


### PR DESCRIPTION
Removed requestBody in Logout, so frontend doesnt need so send additional information. #143, #144 ValidateTeamPaused moved to teamService instead of taskService since ValidateTeamPaused only uses user and team information. I also updated the logout test.