### PR TITLE
#168, #169 Completed; Lucky draw

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Task.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/entity/Task.java
@@ -74,6 +74,9 @@ public class Task implements Serializable {
     @Column(nullable = true)
     private Long teamId;
 
+    @Column(nullable = true)
+    private Boolean luckyDraw;
+
     // Getters and Setters
     public Long getId() {
         return id;
@@ -177,6 +180,14 @@ public class Task implements Serializable {
 
     public void setActiveStatus(Boolean activeStatus) {
         this.activeStatus = activeStatus;
+    }
+
+    public Boolean getLuckyDraw() {
+        return luckyDraw;
+    }
+
+    public void setLuckyDraw(Boolean luckyDraw) {
+        this.luckyDraw = luckyDraw;
     }
 
     public Long getcreatorId() {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/task/TaskGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/dto/task/TaskGetDTO.java
@@ -24,4 +24,5 @@ public class TaskGetDTO {
     private Integer daysVisible;
     private Integer frequency;
     private String startDate;
+    private Boolean luckyDraw;
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/rest/mapper/DTOMapper.java
@@ -105,6 +105,7 @@ public interface DTOMapper {
   @Mapping(source = "daysVisible", target = "daysVisible")
   @Mapping(source = "startDate", target = "startDate", dateFormat = "yyyy-MM-dd")
   @Mapping(source = "frequency", target = "frequency")
+  @Mapping(source = "luckyDraw", target = "luckyDraw")
   TaskGetDTO convertEntityToTaskGetDTO(Task task);
 
   @Mapping(source = "id", target = "id")
@@ -120,6 +121,7 @@ public interface DTOMapper {
   @Mapping(source = "daysVisible", target = "daysVisible")
   @Mapping(source = "frequency", target = "frequency")
   @Mapping(source = "startDate", target = "startDate", dateFormat = "yyyy-MM-dd")
+  @Mapping(source = "luckyDraw", target = "luckyDraw")
   Task convertTaskGetDTOtoEntity(TaskGetDTO taskGetDTO);
 
   @Mapping(source = "isAssignedTo", target = "isAssignedTo")


### PR DESCRIPTION
I implemented lucky draw. I added a new luckyDraw boolean to the task entity and create a new POST /tasks/luckyDraw endpoint that sets every unclaimed/active task's luckyDraw boolean to true. Users cant delete or quit lucky drawn tasks. Upon finishing a such a task or when it expires the lucky draw effect is set to false again (so users can remove or unassign these tasks).